### PR TITLE
add missing include: `cstdint`

### DIFF
--- a/Basics/Enums.h
+++ b/Basics/Enums.h
@@ -7,6 +7,7 @@
 #define ENUMS_H
 
 #include <iostream>
+#include <cstdint>
 
 namespace btrForensics {
     //! Type of an item.


### PR DESCRIPTION
Depending on the build platform, `ItemType` and `DirItemType` without including `cstdint` first leads to compile errors:
```
In file included from /build/source/Basics/Basics.h:5,
                 from /build/source/Trees/Trees.h:4,
                 from /build/source/Pool/Pool.h:7,
                 from /build/source/Pool/Functions.h:11,
                 from /build/source/Pool/Functions.cpp:8:
/build/source/Basics/Enums.h:13:11: warning: elaborated-type-specifier for a scoped enum must not use the 'class' keyword
   13 |     enum  class ItemType : uint8_t {
      |     ~~~~  ^~~~~
      |           -----
/build/source/Basics/Enums.h:13:26: error: found ':' in nested-name-specifier, expected '::'
   13 |     enum  class ItemType : uint8_t {
```
[...]

(fixed by this PR)